### PR TITLE
Add Link and Unlink calls

### DIFF
--- a/keyutils.go
+++ b/keyutils.go
@@ -349,3 +349,29 @@ func ListKeysInKeyRing(keyring KeySerial) ([]*KeyDesc, error) {
 	return keys, nil
 
 }
+
+//
+// Link wraps keyctl_link(3).
+//
+func Link(key KeySerial, keyRing KeySerial) error {
+
+	_, err := C.keyctl_link(C.key_serial_t(key), C.key_serial_t(keyRing))
+
+	if err != nil {
+		return err.(syscall.Errno)
+	}
+	return nil
+}
+
+//
+// Unlink wraps keyctl_unlink(3).
+//
+func Unlink(key KeySerial, keyRing KeySerial) error {
+
+	_, err := C.keyctl_unlink(C.key_serial_t(key), C.key_serial_t(keyRing))
+
+	if err != nil {
+		return err.(syscall.Errno)
+	}
+	return nil
+}


### PR DESCRIPTION
Certain types of keyring configuration require the ability to add keys to
multiple keyrings or remove them from existing keyrings. Add wrappers for
the link and unlink calls in libkeyutils in order to permit this.
